### PR TITLE
Decoupled editor functionality into `Action`s

### DIFF
--- a/include/actions/action.h
+++ b/include/actions/action.h
@@ -1,0 +1,15 @@
+#ifndef ACTION_H
+#define ACTION_H
+
+namespace Pilo
+{
+class Editor;
+class Action
+{
+public:
+    virtual ~Action(){};
+    virtual void execute(Editor& editor) = 0;
+};
+}
+
+#endif  // ACTION_H

--- a/include/actions/delete_action.h
+++ b/include/actions/delete_action.h
@@ -1,0 +1,119 @@
+#ifndef DELETE_ACTION_H
+#define DELETE_ACTION_H
+
+#include "action.h"
+#include "../editor.h"
+
+namespace Pilo
+{
+class DeleteAction : public Action
+{
+public:
+    enum Mode
+    {
+        Char,
+        Word,
+    };
+
+    virtual ~DeleteAction(){};
+
+    void execute(Editor& editor) override
+    {
+        switch (m_mode)
+        {
+            case Mode::Char:
+            {
+                // If a line gets deleted, the cursor will be moved to this index.
+                int new_cursor_pos =
+                    editor.text()[editor.cur_pos_in_editor().y - 1].size() - 1;
+                if (del(editor, editor.cur_pos_in_editor()))
+                {
+                    if (editor.cur_pos_in_editor().x == 0)
+                    {
+                        editor.cursor_pos().y--;
+                        editor.cursor_pos().x = new_cursor_pos;
+                        return;
+                    }
+                    editor.cursor_pos().x--;
+                }
+                break;
+            }
+            case Mode::Word:
+            {
+                if (editor.text()[editor.cur_pos_in_editor().y]
+                                 [editor.cur_pos_in_editor().x - 1] == ' ')
+                {
+                    while (editor.text()[editor.cur_pos_in_editor().y]
+                                        [editor.cur_pos_in_editor().x - 1] == ' ' &&
+                           editor.cur_pos_in_editor().x != 0)
+                    {
+                        if (del(editor, editor.cur_pos_in_editor()))
+                        {
+                            editor.cursor_pos().x--;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    while (editor.text()[editor.cur_pos_in_editor().y]
+                                        [editor.cur_pos_in_editor().x - 1] != ' ' &&
+                           editor.cur_pos_in_editor().x != 0)
+                    {
+                        if (del(editor, editor.cur_pos_in_editor()))
+                        {
+                            editor.cursor_pos().x--;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    bool del(Editor& editor, Vec2 pos)
+    {
+        if (pos.y >= editor.text().size())
+        {
+            return false;
+        }
+        else if (pos.x >= editor.text()[pos.y].size() || pos.x <= 0)
+        {
+            // Handle deleting lines.
+            if (pos.x == 0 && pos.y != 0)
+            {
+                // Lines that only contain '\n'.
+                if (editor.text()[pos.y][pos.x] == '\n')
+                {
+                    editor.text().erase(editor.text().begin() + pos.y);
+                    return true;
+                }
+
+                // Delete the last character (it's always \n).
+                editor.text()[pos.y - 1] = editor.text()[pos.y - 1].substr(
+                    0, editor.text()[pos.y - 1].size() - 1);
+
+                editor.text()[pos.y - 1] += editor.text()[pos.y];
+                editor.text().erase(editor.text().begin() + pos.y);
+                return true;
+            }
+            return false;
+        }
+
+        editor.text()[pos.y].erase(pos.x - 1, 1);
+
+        return true;
+    }
+
+    Mode m_mode;
+};
+}
+
+#endif  // DELETE_ACTION_H

--- a/include/actions/move_cursor_action.h
+++ b/include/actions/move_cursor_action.h
@@ -1,0 +1,101 @@
+#ifndef MOVE_CURSOR_ACTION_H
+#define MOVE_CURSOR_ACTION_H
+
+#include "action.h"
+#include "../editor.h"
+
+namespace Pilo
+{
+class MoveCursorAction : public Action
+{
+public:
+    enum Direction
+    {
+        Up,
+        Down,
+        Right,
+        Left
+    };
+
+    virtual ~MoveCursorAction(){};
+
+    void execute(Editor& editor) override
+    {
+        switch (m_dir)
+        {
+            case Direction::Up:
+                move_cursor_up(editor);
+                break;
+            case Direction::Down:
+                move_cursor_down(editor);
+                break;
+            case Direction::Left:
+                move_cursor_left(editor);
+                break;
+            case Direction::Right:
+                move_cursor_right(editor);
+                break;
+        }
+    }
+
+    void move_cursor_up(Editor& editor)
+    {
+        editor.cursor_pos().y--;
+        if (editor.cursor_pos().y < 0)
+        {
+            if (editor.starting_line() != 0)
+                editor.starting_line()--;
+
+            editor.cursor_pos().y = 0;
+        }
+        else if (editor.text()[editor.cur_pos_in_editor().y].size() <=
+                 editor.cur_pos_in_editor().x)
+        {
+            editor.cursor_pos().x =
+                editor.text()[editor.cur_pos_in_editor().y].size() - 1;
+        }
+    }
+    void move_cursor_down(Editor& editor)
+    {
+        editor.cursor_pos().y++;
+        if (editor.cursor_pos().y >= editor.win_size().y)
+        {
+            if (editor.starting_line() + editor.cursor_pos().y < editor.text().size())
+                editor.starting_line()++;
+
+            editor.cursor_pos().y = editor.win_size().y - 1;
+        }
+        else if (editor.text()[editor.cur_pos_in_editor().y].size() <=
+                 editor.cur_pos_in_editor().x)
+        {
+            editor.cursor_pos().x =
+                editor.text()[editor.cur_pos_in_editor().y].size() - 1;
+        }
+    }
+    void move_cursor_left(Editor& editor)
+    {
+        if (editor.cursor_pos().y == 0 && editor.cursor_pos().x == 0)
+            return;
+
+        editor.cursor_pos().x--;
+        if (editor.cursor_pos().x < 0)
+        {
+            move_cursor_up(editor);
+        }
+    }
+    void move_cursor_right(Editor& editor)
+    {
+        editor.cursor_pos().x++;
+        if (editor.cur_pos_in_editor().x >=
+            editor.text()[editor.cur_pos_in_editor().y].size())
+        {
+            move_cursor_down(editor);
+            editor.cursor_pos().x = 0;
+        }
+    }
+
+    Direction m_dir;
+};
+}
+
+#endif  //  MOVE_CURSOR_ACTION_H

--- a/include/actions/quit_action.h
+++ b/include/actions/quit_action.h
@@ -1,0 +1,21 @@
+#ifndef QUIT_ACTION_H
+#define QUIT_ACTION_H
+
+#include "action.h"
+#include "../editor.h"
+
+namespace Pilo
+{
+class QuitAction : public Action
+{
+public:
+    virtual ~QuitAction(){};
+
+    void execute(Editor& editor) override
+    {
+        editor.die();
+    }
+};
+}
+
+#endif  // QUIT_ACTION_H

--- a/include/actions/save_file_action.h
+++ b/include/actions/save_file_action.h
@@ -1,0 +1,32 @@
+#ifndef SAVE_FILE_ACTION_H
+#define SAVE_FILE_ACTION_H
+
+#include <string_view>
+#include <fstream>
+
+#include "action.h"
+#include "../editor.h"
+
+namespace Pilo
+{
+class SaveFileAction : public Action
+{
+public:
+    virtual ~SaveFileAction(){};
+
+    void execute(Editor& editor) override
+    {
+        std::ofstream file{m_filename.data(), std::ios_base::trunc};
+        file.exceptions(std::ifstream::badbit | std::ifstream::failbit);
+
+        for (const auto& row : editor.text())
+        {
+            file << row;
+        }
+    }
+
+    std::string_view m_filename;
+};
+}
+
+#endif  // SAVE_FILE_ACTION_H

--- a/include/actions/write_action.h
+++ b/include/actions/write_action.h
@@ -1,0 +1,78 @@
+#ifndef WRITE_ACTION_H
+#define WRITE_ACTION_H
+
+#include "../editor.h"
+#include "../vec2.h"
+#include "action.h"
+
+namespace Pilo
+{
+class WriteAction : public Action
+{
+public:
+    virtual ~WriteAction(){};
+
+    void execute(Editor& editor) override
+    {
+        switch (m_ch)
+        {
+            case '\n':
+                if (write(editor, editor.cur_pos_in_editor(), '\n'))
+                {
+                    editor.cursor_pos().y++;
+                    if (editor.cursor_pos().y >= editor.win_size().y)
+                    {
+                        if (editor.cur_pos_in_editor().y < editor.text().size())
+                            editor.starting_line()++;
+
+                        editor.cursor_pos().y = editor.win_size().y - 1;
+                    }
+                    editor.cursor_pos().x = 0;
+                }
+                break;
+            case '\t':
+                if (write(editor, editor.cur_pos_in_editor(), ' '))
+                {
+                    write(editor, editor.cur_pos_in_editor(), ' ');
+                    write(editor, editor.cur_pos_in_editor(), ' ');
+                    write(editor, editor.cur_pos_in_editor(), ' ');
+                }
+                break;
+            default:
+                write(editor, m_pos, m_ch);
+                break;
+        }
+    }
+
+    bool write(Editor& editor, Vec2 pos, char ch)
+    {
+        if (pos.y >= editor.text().size())
+        {
+            return false;
+        }
+        else if (pos.x >= editor.text()[pos.y].size())
+        {
+            return false;
+        }
+
+        editor.text()[pos.y].insert(pos.x, 1, ch);
+
+        if (ch == '\n')
+        {
+            editor.text().insert(editor.text().begin() + pos.y + 1,
+                                 editor.text()[pos.y].substr(pos.x + 1));
+            // Remove the contents that were appended from the previous line.
+            editor.text()[pos.y] = editor.text()[pos.y].substr(0, pos.x + 1);
+        }
+
+        editor.cursor_pos().x++;
+
+        return true;
+    }
+
+    Vec2 m_pos;
+    char m_ch;
+};
+}
+
+#endif  // WRITE_ACTION_H


### PR DESCRIPTION
- Now editor functionality is defined in `Action`s, separate classes
  that perform one specific task (or maybe several :)). The main editor
  class loops over a vector of `Action`s every draw loop and executes
  them all.
- Fixed a bug with being able to move to position -1;0.
- The editor window now scrolls down if you write a newline at the
  bottom of the screen.