### PR TITLE
Fixed backspace recognition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.0)
+cmake_minimum_required(VERSION 3.16.3)
 project(pilo)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -26,8 +26,6 @@ set(CXX_LINK_LIBS)
 list(APPEND CXX_INCLUDE_DIRS "include")
 
 # fmtlib
-find_package(fmt)
-list(APPEND CXX_LINK_LIBS fmt::fmt-header-only)
 list(APPEND CXX_LINK_LIBS ncurses)
 
 target_compile_options(pilo PRIVATE ${CXX_COMPILE_FLAGS})

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -85,7 +85,7 @@ void Editor::process_input()
             m_actions.emplace_back(std::make_unique<SaveFileAction>(action));
             break;
         }
-        case g_key_ctrl_backspace:
+        case ctrl_key(8):
         {
             DeleteAction action;
             action.m_mode = DeleteAction::Mode::Word;
@@ -121,6 +121,7 @@ void Editor::process_input()
             break;
         }
         case g_key_backspace:
+        case KEY_BACKSPACE:
         {
             DeleteAction action;
             action.m_mode = DeleteAction::Mode::Char;
@@ -167,12 +168,12 @@ void Editor::render_status_window()
     move_cursor(m_status_window, {0, 0});
 
     wattron(m_status_window, COLOR_PAIR(ColorStatusWin) | A_BOLD);
-    // wprintw(m_status_window, "%s -- %s\n", m_filename.c_str(),
-    //         get_current_time().c_str());
+    wprintw(m_status_window, "%s -- %s\n", m_filename.c_str(),
+            get_current_time().c_str());
     // ! Debug information.
-    wprintw(m_status_window, "%d;%d", cur_pos_in_editor().x, cur_pos_in_editor().y);
-    if (m_text.size() > cur_pos_in_editor().y)
-        wprintw(m_status_window, " -- %s", m_text[cur_pos_in_editor().y].c_str());
+    // wprintw(m_status_window, "%d;%d", cur_pos_in_editor().x, cur_pos_in_editor().y);
+    // if (m_text.size() > cur_pos_in_editor().y)
+    //     wprintw(m_status_window, " -- %s", m_text[cur_pos_in_editor().y].c_str());
     wattroff(m_status_window, COLOR_PAIR(ColorStatusWin) | A_BOLD);
 }
 


### PR DESCRIPTION
- Backspace is now properly recognized.
- Switched from showing debug info in status window to normal info.
- Removed {fmt} library requirement.
- Reduced required CMake version down to 3.16.3